### PR TITLE
CollectionViewの削除機能を追加

### DIFF
--- a/MovieReviewMVP.xcodeproj/project.pbxproj
+++ b/MovieReviewMVP.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		75699F3C264BCE28001904C4 /* ReviewManagementCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75699F3A264BCE28001904C4 /* ReviewManagementCollectionViewCell.swift */; };
 		75699F3D264BCE28001904C4 /* ReviewManagementCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 75699F3B264BCE28001904C4 /* ReviewManagementCollectionViewCell.xib */; };
 		75699F48264BD307001904C4 /* ReviewManagementCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75699F47264BD307001904C4 /* ReviewManagementCollectionViewController.swift */; };
+		756C9C2F26536518003BA3F6 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756C9C2E26536518003BA3F6 /* Array.swift */; };
 		756DFC8F264CCBF500C6AF07 /* ReviewManagement.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 756DFC8E264CCBF500C6AF07 /* ReviewManagement.storyboard */; };
 		756DFCB5264D0DFA00C6AF07 /* MovieUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756DFCB4264D0DFA00C6AF07 /* MovieUseCase.swift */; };
 		756DFCBB264D5B6900C6AF07 /* State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 756DFCBA264D5B6900C6AF07 /* State.swift */; };
@@ -98,6 +99,7 @@
 		75699F3A264BCE28001904C4 /* ReviewManagementCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewManagementCollectionViewCell.swift; sourceTree = "<group>"; };
 		75699F3B264BCE28001904C4 /* ReviewManagementCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewManagementCollectionViewCell.xib; sourceTree = "<group>"; };
 		75699F47264BD307001904C4 /* ReviewManagementCollectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewManagementCollectionViewController.swift; sourceTree = "<group>"; };
+		756C9C2E26536518003BA3F6 /* Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
 		756DFC8E264CCBF500C6AF07 /* ReviewManagement.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = ReviewManagement.storyboard; path = MovieReviewMVP/ReviewManagement/ReviewManagement.storyboard; sourceTree = SOURCE_ROOT; };
 		756DFCB4264D0DFA00C6AF07 /* MovieUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieUseCase.swift; sourceTree = "<group>"; };
 		756DFCBA264D5B6900C6AF07 /* State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = State.swift; sourceTree = "<group>"; };
@@ -197,6 +199,7 @@
 		75676EDA263A89B400569AF5 /* MovieReviewMVP */ = {
 			isa = PBXGroup;
 			children = (
+				756C9C2D265364FD003BA3F6 /* extension */,
 				756DFCB9264D5B5500C6AF07 /* State */,
 				75676EDB263A89B400569AF5 /* AppDelegate.swift */,
 				75676EDD263A89B400569AF5 /* SceneDelegate.swift */,
@@ -273,6 +276,14 @@
 				755D71E0264385F5007C0D77 /* ReviewMovie.xib */,
 			);
 			path = Xib;
+			sourceTree = "<group>";
+		};
+		756C9C2D265364FD003BA3F6 /* extension */ = {
+			isa = PBXGroup;
+			children = (
+				756C9C2E26536518003BA3F6 /* Array.swift */,
+			);
+			path = extension;
 			sourceTree = "<group>";
 		};
 		756DFCB1264D0D9F00C6AF07 /* DataStores */ = {
@@ -577,6 +588,7 @@
 				75359213264E61B9004477B3 /* ReviewMovieOwner.swift in Sources */,
 				756E4EAE26468334009AA060 /* MovieDatabase.swift in Sources */,
 				75676F33263AA2FA00569AF5 /* TMDB.swift in Sources */,
+				756C9C2F26536518003BA3F6 /* Array.swift in Sources */,
 				75676F15263A954000569AF5 /* SearchMovieModel.swift in Sources */,
 				75676EDE263A89B400569AF5 /* SceneDelegate.swift in Sources */,
 				75676F10263A953100569AF5 /* SearchMoviePresenter.swift in Sources */,

--- a/MovieReviewMVP/Cells/ReviewManagementCollectionViewCell.swift
+++ b/MovieReviewMVP/Cells/ReviewManagementCollectionViewCell.swift
@@ -23,6 +23,7 @@ class ReviewManagementCollectionViewCell: UICollectionViewCell {
     func configure(movieReview: MovieReviewElement) {
         reviewView.rating = movieReview.reviewStars
         reviewView.text = String(movieReview.reviewStars)
+        
         guard let posterUrl = URL(string: TMDBPosterURL(posterPath: movieReview.movieImagePath).posterURL) else { return }
         let task = URLSession.shared.dataTask(with: posterUrl) { (data, resopnse, error) in
             guard let imageData = data else { return }
@@ -41,6 +42,14 @@ class ReviewManagementCollectionViewCell: UICollectionViewCell {
     func setupLayout(width: CGFloat) {
         movieImageView.layoutIfNeeded()
         movieImageView.layer.cornerRadius = width * 0.03
+    }
+    
+    func selectedCell() {
+        alpha = 0.5
+    }
+    
+    func deselectedCell() {
+        alpha = 1
     }
     
 }

--- a/MovieReviewMVP/Domain/DataStores/MovieDataStore.swift
+++ b/MovieReviewMVP/Domain/DataStores/MovieDataStore.swift
@@ -18,10 +18,18 @@ struct MovieDataStore : MovieReviewRepository {
         notificationToken = results.observe { changes in
             switch changes {
             case .initial:
-                presenter.returnReviewContent()
+                presenter.updateReviewMovies(.initial, nil)
                 print("初期表示を行いました")
             case let .update(_, deletions, insertions, modifications):
-                presenter.returnReviewContent()
+                
+                if let deletionIndex = deletions.first {
+                    presenter.updateReviewMovies(.delete, deletionIndex)
+                } else if let insertionIndex = insertions.first {
+                    presenter.updateReviewMovies(.insert, insertionIndex)
+                } else if let modificationIndex = modifications.first {
+                    presenter.updateReviewMovies(.modificate, modificationIndex)
+                }
+
                 print("更新処理を行いました",deletions, insertions, modifications)
             case let .error(error):
                 print(error)

--- a/MovieReviewMVP/ReviewManagement/ReviewManagement.storyboard
+++ b/MovieReviewMVP/ReviewManagement/ReviewManagement.storyboard
@@ -36,9 +36,16 @@
                             <constraint firstItem="TBe-6n-WPe" firstAttribute="leading" secondItem="TUH-qs-qL5" secondAttribute="leading" constant="10" id="zrR-te-Qay"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="HGn-4s-VNT"/>
+                    <navigationItem key="navigationItem" id="HGn-4s-VNT">
+                        <barButtonItem key="rightBarButtonItem" systemItem="trash" id="85M-SP-O1o">
+                            <connections>
+                                <action selector="trashButtonTapped:" destination="fnF-bp-mOz" id="fRk-yr-G9l"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
                         <outlet property="collectionView" destination="TBe-6n-WPe" id="y5H-zf-CZG"/>
+                        <outlet property="trashButton" destination="85M-SP-O1o" id="iWT-bu-0ii"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZQ5-aB-otn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/MovieReviewMVP/ReviewManagement/ReviewManagementPresenter.swift
+++ b/MovieReviewMVP/ReviewManagement/ReviewManagementPresenter.swift
@@ -8,17 +8,25 @@
 import Foundation
 
 protocol ReviewManagementPresenterInput {
-    func returnReviewContent()
     var numberOfMovies: Int { get }
     func movieReview(forRow row: Int) -> MovieReviewElement?
-    func didDeleteReviewMovie(index: IndexPath)
+    func didDeleteReviewMovie(indexs: [IndexPath]?)
+    func changeEditingStateProcess(_ editing: Bool, _ indexPaths: [IndexPath]?)
+    func updateReviewMovies(_ state: movieUpdateState, _ index: Int?)
+    
 }
 
 protocol ReviewManagementPresenterOutput: AnyObject {
-    func updataMovieReview()
+    func deselectItem(_ editing: Bool, _ indexPaths: [IndexPath]?)
+    func updateItem(_ state: movieUpdateState, _ index: Int?)
+
 }
 
+
+
 class ReviewManagementPresenter : ReviewManagementPresenterInput {
+    
+    
     
     private weak var view: ReviewManagementPresenterOutput!
     
@@ -28,27 +36,41 @@ class ReviewManagementPresenter : ReviewManagementPresenterInput {
         self.view = view
         self.model = model
     }
+    
     private(set) var movieReviewElements: [MovieReviewElement] = []
     
     var numberOfMovies: Int {
         return movieReviewElements.count
     }
-
-    func returnReviewContent() {
+    
+    func updateReviewMovies(_ state: movieUpdateState, _ index: Int?) {
         let movieUseCase = MovieUseCase()
         let movieReviewElements = movieUseCase.fetch()
         self.movieReviewElements = movieReviewElements
-        view.updataMovieReview()
+        
+        view.updateItem(state, index)
     }
+
     
-    func didDeleteReviewMovie(index: IndexPath) {
-        model.deleteReviewMovie(index)
-        returnReviewContent()
+    func didDeleteReviewMovie(indexs: [IndexPath]?) {
+        print(indexs!)
+        if var selectedIndexPaths = indexs {
+            selectedIndexPaths.sort { $0 > $1 }
+            for index in selectedIndexPaths {
+                model.deleteReviewMovie(index)
+            }
+        }
         
     }
     
     func movieReview(forRow row: Int) -> MovieReviewElement? {
         movieReviewElements[row]
     }
+    
+    
+    func changeEditingStateProcess(_ editing: Bool, _ indexPaths: [IndexPath]?) {
+            view.deselectItem(editing, indexPaths)
+    }
+
 
 }

--- a/MovieReviewMVP/State/State.swift
+++ b/MovieReviewMVP/State/State.swift
@@ -21,3 +21,10 @@ enum fetchMovieState {
         }
     }
 }
+
+enum movieUpdateState {
+    case initial
+    case delete
+    case insert
+    case modificate
+}

--- a/MovieReviewMVP/extension/Array.swift
+++ b/MovieReviewMVP/extension/Array.swift
@@ -1,0 +1,16 @@
+//
+//  Array.swift
+//  MovieReviewMVP
+//
+//  Created by 坂本龍哉 on 2021/05/18.
+//
+
+import Foundation
+
+extension Array where Element: Equatable {
+    mutating func remove(value: Element) {
+        if let i = self.firstIndex(of: value) {
+            self.remove(at: i)
+        }
+    }
+}


### PR DESCRIPTION
## 変更点
CollectionViewに削除機能を追加しました。
更新処理もenumで管理するように変更しました。
## どうやって使うか
編集モードに切り替えると、cellが選択できるようになるので、選択してtrashボタンを押すことで、削除可能になります。
enumに関しては、initial・delete・insert・modificateの4つに分け、引数に渡すことで処理を切り替えています。
## なぜ変更/追加したか
必須機能のため追加しました。
enumは可読性が増し、コードもスッキリするので採用しました。
## スクショ（UI変更がある場合）
