### PR TITLE
レビュー作成日順で保存、表示できるように処理を追加しました。

### DIFF
--- a/MovieReviewMVP/Domain/DataStores/MovieDataStore.swift
+++ b/MovieReviewMVP/Domain/DataStores/MovieDataStore.swift
@@ -14,7 +14,7 @@ struct MovieDataStore : MovieReviewRepository {
     mutating func notification(_ presenter: ReviewManagementPresenterInput) {
         
         let realm = try! Realm()
-        let results = realm.objects(RealmMyMovieInfomation.self)
+        let results = realm.objects(RealmMyMovieInfomation.self).sorted(byKeyPath: sortState.created.keyPath)
 
         notificationToken = results.observe { changes in
             switch changes {
@@ -25,9 +25,11 @@ struct MovieDataStore : MovieReviewRepository {
                 
                 if let deletionIndex = deletions.first {
                     presenter.updateReviewMovies(.delete, deletionIndex)
+                    print(deletionIndex)
                 } else if let insertionIndex = insertions.first {
                     presenter.updateReviewMovies(.insert, insertionIndex)
                 } else if let modificationIndex = modifications.first {
+                    
                     presenter.updateReviewMovies(.modificate, modificationIndex)
                 }
 
@@ -37,7 +39,6 @@ struct MovieDataStore : MovieReviewRepository {
             }
         }
     }
-    
     
     func createMovieReview(_ movie: MovieReviewElement) {
         let realmMyMovieInfomation = RealmMyMovieInfomation()
@@ -49,7 +50,7 @@ struct MovieDataStore : MovieReviewRepository {
         realmMyMovieInfomation.overview = movie.overview ?? ""
         realmMyMovieInfomation.review = movie.review ?? ""
         realmMyMovieInfomation.movieImagePath = movie.poster_path ?? ""
-        
+        realmMyMovieInfomation.created_at = movie.create_at ?? Date()
         
         
         try! realm.write {
@@ -62,7 +63,7 @@ struct MovieDataStore : MovieReviewRepository {
     func fetchMovieReview() -> [MovieReviewElement] {
         var realmMyMovieInfomations: [RealmMyMovieInfomation] = []
         let realm = try! Realm()
-         let fetchedMovies = realm.objects(RealmMyMovieInfomation.self)
+         let fetchedMovies = realm.objects(RealmMyMovieInfomation.self).sorted(byKeyPath: sortState.created.keyPath)
         for movie in fetchedMovies {
             realmMyMovieInfomations.append(movie)
         }
@@ -71,7 +72,7 @@ struct MovieDataStore : MovieReviewRepository {
         
         for movie in realmMyMovieInfomations {
             
-            movieReviewElements.append(MovieReviewElement(title: movie.title, poster_path: movie.movieImagePath, original_name: movie.original_name, backdrop_path: movie.backdrop_path, overview: movie.overview, releaseDay: movie.releaseDay, reviewStars: movie.reviewStars, review: movie.review))
+            movieReviewElements.append(MovieReviewElement(title: movie.title, poster_path: movie.movieImagePath, original_name: movie.original_name, backdrop_path: movie.backdrop_path, overview: movie.overview, releaseDay: movie.releaseDay, reviewStars: movie.reviewStars, review: movie.review, create_at: movie.created_at))
             
         }
         return movieReviewElements
@@ -86,6 +87,7 @@ struct MovieDataStore : MovieReviewRepository {
         realmMyMovieInfomation.overview = movie.overview ?? ""
         realmMyMovieInfomation.review = movie.review ?? ""
         realmMyMovieInfomation.movieImagePath = movie.poster_path ?? ""
+        realmMyMovieInfomation.created_at = movie.create_at ?? Date()
 
         let realm = try! Realm()
         
@@ -97,13 +99,24 @@ struct MovieDataStore : MovieReviewRepository {
     
     func deleteMovieReview(_ index: IndexPath) {
         let realm = try! Realm()
-        let realmMyMovieInfomations = realm.objects(RealmMyMovieInfomation.self)
+        let realmMyMovieInfomations = realm.objects(RealmMyMovieInfomation.self).sorted(byKeyPath: sortState.created.keyPath)
+        print(realmMyMovieInfomations)
+        print("*********************************************************")
         
         try! realm.write {
+            print(realmMyMovieInfomations[index.row])
             realm.delete(realmMyMovieInfomations[index.row])
+            
         }
     }
     
+    
+    func sortMovieReview(_ movie: MovieReviewElement) {
+        let realm = try! Realm()
+        
+        let sortedStoreDate = realm.objects(RealmMyMovieInfomation.self).sorted(byKeyPath: sortState.created.keyPath)
+    }
+
 
     
 }

--- a/MovieReviewMVP/Domain/Movie.swift
+++ b/MovieReviewMVP/Domain/Movie.swift
@@ -23,6 +23,7 @@ struct MovieReviewElement {
     var releaseDay: String?
     var reviewStars: Double?
     var review: String?
+    var create_at: Date?
 }
 
 

--- a/MovieReviewMVP/Domain/MovieDatabase.swift
+++ b/MovieReviewMVP/Domain/MovieDatabase.swift
@@ -16,6 +16,8 @@ class RealmMyMovieInfomation: Object {
     @objc dynamic var movieImagePath: String = ""
     @objc dynamic var original_name: String = ""
     @objc dynamic var backdrop_path: String = ""
+    @objc dynamic var created_at: Date = Date()
+
     
     override class func primaryKey() -> String? {
         "title"

--- a/MovieReviewMVP/Domain/Repositories/MovieRepository.swift
+++ b/MovieReviewMVP/Domain/Repositories/MovieRepository.swift
@@ -12,6 +12,7 @@ protocol MovieReviewRepository {
     func fetchMovieReview() -> [MovieReviewElement]
     func updateMovieReview(_ movie: MovieReviewElement)
     func deleteMovieReview(_ index: IndexPath)
+    func sortMovieReview(_ movie: MovieReviewElement)
     mutating func notification(_ presenter: ReviewManagementPresenterInput)
 }
 

--- a/MovieReviewMVP/ReviewManagement/ReviewManagementCollectionViewController.swift
+++ b/MovieReviewMVP/ReviewManagement/ReviewManagementCollectionViewController.swift
@@ -178,10 +178,9 @@ extension ReviewManagementCollectionViewController : ReviewManagementPresenterOu
         case .delete:
             guard let index = index else { return }
             collectionView.deleteItems(at: [IndexPath(item: index, section: 0)])
-
         case .insert:
-            guard let index = index else { return }
-            collectionView.insertItems(at: [IndexPath(item: index, section: 0)])
+            
+            collectionView.reloadData()
 
         case .modificate:
             guard let index = index else { return }

--- a/MovieReviewMVP/ReviewManagement/ReviewManagementPresenter.swift
+++ b/MovieReviewMVP/ReviewManagement/ReviewManagementPresenter.swift
@@ -47,6 +47,8 @@ class ReviewManagementPresenter : ReviewManagementPresenterInput {
         let movieUseCase = MovieUseCase()
         let movieReviewElements = movieUseCase.fetch()
         self.movieReviewElements = movieReviewElements
+        print(movieReviewElements)
+
         view.updateItem(state, index)
     }
     
@@ -63,11 +65,11 @@ class ReviewManagementPresenter : ReviewManagementPresenterInput {
         print(indexs!)
         if var selectedIndexPaths = indexs {
             selectedIndexPaths.sort { $0 > $1 }
+            print(selectedIndexPaths)
             for index in selectedIndexPaths {
                 model.deleteReviewMovie(index)
             }
         }
-        
     }
     
     func movieReview(forRow row: Int) -> MovieReviewElement? {

--- a/MovieReviewMVP/ReviewMovie/ReviewMovieModel.swift
+++ b/MovieReviewMVP/ReviewMovie/ReviewMovieModel.swift
@@ -8,26 +8,29 @@
 import Foundation
 
 protocol ReviewMovieModelInput {
-    func createMovieReview(_ movie: MovieReviewElement)
-    func modificateMovieReview(_ movie: MovieReviewElement)
-
+    func reviewMovie(movieReviewState: MovieReviewState, _ movie: MovieReviewElement)
 }
 
 final class ReviewMovieModel : ReviewMovieModelInput {
+    
     
     private var movieReviewElement: MovieReviewElement?
     init(movie: MovieReviewElement?, movieReviewElement: MovieReviewElement?) {
         self.movieReviewElement = movie
     }
     
-    func createMovieReview(_ movie: MovieReviewElement) {
+    func reviewMovie(movieReviewState: MovieReviewState, _ movie: MovieReviewElement) {
+        
         let movieUseCase = MovieUseCase()
-        movieUseCase.create(movie)
+
+        switch movieReviewState {
+        case .beforeStore:
+            movieUseCase.create(movie)
+        case .afterStore:
+            movieUseCase.update(movie)
+        }
+        
     }
-    
-    func modificateMovieReview(_ movie: MovieReviewElement) {
-        let movieUseCase = MovieUseCase()
-        movieUseCase.update(movie)
-    }
+
     
 }

--- a/MovieReviewMVP/ReviewMovie/ReviewMoviePresenter.swift
+++ b/MovieReviewMVP/ReviewMovie/ReviewMoviePresenter.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol ReviewMoviePresenterInput {
     func viewDidLoad()
-    func didTapSaveButton(reviewScore: Double, review: String)
+    func didTapSaveButton(date: Date, reviewScore: Double, review: String)
     func returnMovieReviewState() -> MovieReviewState
 }
 
@@ -18,9 +18,6 @@ protocol ReviewMoviePresenterOutput : AnyObject {
 }
 
 final class ReviewMoviePresenter : ReviewMoviePresenterInput {
-    func returnMovieReviewState() -> MovieReviewState {
-        movieReviewState
-    }
     
     
     private var movieReviewState: MovieReviewState
@@ -44,21 +41,32 @@ final class ReviewMoviePresenter : ReviewMoviePresenterInput {
             self.view.displayReviewMovie(movieReviewState: movieReviewState, movieReviewElement)
         case .afterStore:
             self.view.displayReviewMovie(movieReviewState: movieReviewState, movieReviewElement)
-            print(movieReviewElement)
         }
     }
     
-    // MARK: 保存ボタンが押された時の処理
-    func didTapSaveButton(reviewScore: Double, review: String) {
+    // MARK: どこから画面遷移されたのかをenumで区別
+    func returnMovieReviewState() -> MovieReviewState {
+        movieReviewState
+    }
 
-        movieReviewElement.reviewStars = reviewScore
-        movieReviewElement.review = review
+    
+    // MARK: 保存ボタンが押された時の処理
+    func didTapSaveButton(date: Date, reviewScore: Double, review: String) {
         
         switch movieReviewState {
         case .beforeStore:
-            model.createMovieReview(movieReviewElement)
+            movieReviewElement.create_at = date
+            movieReviewElement.reviewStars = reviewScore
+            movieReviewElement.review = review
+            print(movieReviewElement.create_at)
+            
         case .afterStore:
-            model.modificateMovieReview(movieReviewElement)
+            movieReviewElement.reviewStars = reviewScore
+            movieReviewElement.review = review
+            print(movieReviewElement.create_at)
         }
+
+        model.reviewMovie(movieReviewState: movieReviewState, movieReviewElement)
+
     }
 }

--- a/MovieReviewMVP/ReviewMovie/ReviewMovieViewController.swift
+++ b/MovieReviewMVP/ReviewMovie/ReviewMovieViewController.swift
@@ -46,6 +46,7 @@ private extension ReviewMovieViewController {
 
     func setNavigationController() {
         
+        // MARK: ボタンの表示内容を分ける
         switch presenter.returnMovieReviewState() {
         case .beforeStore:
             saveButton = UIBarButtonItem(title: "保存", style: .done, target: self, action: #selector(saveButtonTapped))
@@ -73,7 +74,7 @@ private extension ReviewMovieViewController {
 private extension ReviewMovieViewController {
     
     @objc func saveButtonTapped(_ sender: UIBarButtonItem) {
-        presenter.didTapSaveButton(reviewScore: Double(reviewMovieOwner.reviewStarView.text!) ?? 0.0, review: reviewMovieOwner.reviewTextView.text ?? "")
+        presenter.didTapSaveButton(date: Date(), reviewScore: Double(reviewMovieOwner.reviewStarView.text!) ?? 0.0, review: reviewMovieOwner.reviewTextView.text ?? "")
         dismiss(animated: true, completion: nil)
     }
 

--- a/MovieReviewMVP/SearchMovie/SearchMovieModel.swift
+++ b/MovieReviewMVP/SearchMovie/SearchMovieModel.swift
@@ -69,7 +69,8 @@ private extension MovieReviewElement {
                                   overview: movieInfomation.overview,
                                   releaseDay: movieInfomation.release_date,
                                   reviewStars: nil,
-                                  review: nil)
+                                  review: nil,
+                                  create_at: nil)
     }
 }
 

--- a/MovieReviewMVP/SearchMovie/SearchMoviePresenter.swift
+++ b/MovieReviewMVP/SearchMovie/SearchMoviePresenter.swift
@@ -39,6 +39,7 @@ final class SearchMoviePresenter : SearchMoviePresenterInput {
     }
     
     func didSelectRow(at indexPath: IndexPath) {
+        
         view.reviewTheMovie(movie: movies[indexPath.row])
     }
     

--- a/MovieReviewMVP/State/State.swift
+++ b/MovieReviewMVP/State/State.swift
@@ -47,3 +47,21 @@ enum CellSelectedState {
         }
     }
 }
+
+enum sortState {
+    case created
+    case title
+    case reviewStar
+        
+    
+    var keyPath: String {
+        switch self {
+        case .created:
+            return "created_at"
+        case .title:
+            return "title"
+        case .reviewStar:
+            return "reviewStars"
+        }
+    }
+}


### PR DESCRIPTION
## 変更点
realmの項目にレビュー日に該当するcreated_atを追加しました。
## どうやって使うか
レビュー作成時は、レビュー作成日時を保存し、作成順で並び替えます。
レビュー更新時は、レビュー作成日時を更新しないので、順番は変わりません。
## なぜ変更/追加したか
レビュー内容の更新をnotificationで行うにはprimarykeyを使用する必要があり、そうすると、保存順もバラバラになります。
保存順を維持するために、作成日をrealmの項目に追加して、sortする必要がありました。
## スクショ（UI変更がある場合）
なし。
## 備考
今後、sort機能を追加予定。
作成日だけではなく、高評価順、名前順など