### PR TITLE
Notificationを使って更新処理追加、realmのnotificationを削除

### DIFF
--- a/MovieReviewMVP.xcodeproj/project.pbxproj
+++ b/MovieReviewMVP.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		750B44002685A1A400191E17 /* UIMenu+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B43FF2685A1A400191E17 /* UIMenu+Ext.swift */; };
 		750B440B2685CF0A00191E17 /* Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B440A2685CF0A00191E17 /* Date.swift */; };
 		750B44612687096F00191E17 /* ReviewTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B44602687096F00191E17 /* ReviewTextView.swift */; };
+		750B44B52689C32D00191E17 /* Notification.Name+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 750B44B42689C32D00191E17 /* Notification.Name+Ext.swift */; };
 		75359213264E61B9004477B3 /* ReviewMovieOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75359212264E61B9004477B3 /* ReviewMovieOwner.swift */; };
 		755D71E1264385F5007C0D77 /* ReviewMovie.xib in Resources */ = {isa = PBXBuildFile; fileRef = 755D71E0264385F5007C0D77 /* ReviewMovie.xib */; };
 		755D71E626438F2E007C0D77 /* ReviewMovieViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755D71E526438F2E007C0D77 /* ReviewMovieViewController.swift */; };
@@ -83,6 +84,7 @@
 		750B43FF2685A1A400191E17 /* UIMenu+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIMenu+Ext.swift"; sourceTree = "<group>"; };
 		750B440A2685CF0A00191E17 /* Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Date.swift; sourceTree = "<group>"; };
 		750B44602687096F00191E17 /* ReviewTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewTextView.swift; sourceTree = "<group>"; };
+		750B44B42689C32D00191E17 /* Notification.Name+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+Ext.swift"; sourceTree = "<group>"; };
 		75359212264E61B9004477B3 /* ReviewMovieOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewMovieOwner.swift; sourceTree = "<group>"; };
 		755D71E0264385F5007C0D77 /* ReviewMovie.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewMovie.xib; sourceTree = "<group>"; };
 		755D71E526438F2E007C0D77 /* ReviewMovieViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewMovieViewController.swift; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 				756AD27E26832B1200BF5D6A /* UIAlertController+Ext.swift */,
 				756AD28C268469A500BF5D6A /* String+Ext.swift */,
 				750B43FF2685A1A400191E17 /* UIMenu+Ext.swift */,
+				750B44B42689C32D00191E17 /* Notification.Name+Ext.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -648,6 +651,7 @@
 				756620E82647B15C00D211EC /* ReviewManagementModel.swift in Sources */,
 				75699F3C264BCE28001904C4 /* ReviewManagementCollectionViewCell.swift in Sources */,
 				75699F2E264BC696001904C4 /* MovieDataStore.swift in Sources */,
+				750B44B52689C32D00191E17 /* Notification.Name+Ext.swift in Sources */,
 				7569BAB62679F0530058D495 /* StockReviewMovieManagementPresenter.swift in Sources */,
 				756D8FB3267308210026889B /* StockReviewMovieCollectionViewCell.swift in Sources */,
 				750B44002685A1A400191E17 /* UIMenu+Ext.swift in Sources */,

--- a/MovieReviewMVP/Domain/DataStores/MovieDataStore.swift
+++ b/MovieReviewMVP/Domain/DataStores/MovieDataStore.swift
@@ -9,43 +9,6 @@ import RealmSwift
 
 struct MovieDataStore : MovieReviewRepository {
     
-    var notificationToken: NotificationToken?
-    
-//     MARK: 更新通知を受け取り、collectionViewをreload
-    mutating func notification(_ presenter: ReviewManagementPresenterInput) {
-
-        let realm = try! Realm()
-        // １回しか呼ばれてない
-        let results = realm.objects(RealmMyMovieInfomation.self).sorted(byKeyPath: presenter.returnSortState().keyPath)
-
-//        print("NotificationのsortState → \(presenter.returnSortState())")
-//        print("通知受け取り時の\(results)")
-
-        notificationToken = results.observe { changes in
-            switch changes {
-            case .initial:
-                presenter.fetchUpdateReviewMovies(.initial)
-                print("初期表示を行いました")
-            case let .update(_, deletions, insertions, modifications):
-                if deletions.first != nil {
-//                    presenter.deleteReviewMovies(.delete)
-                    print("削除しました")
-
-                } else if insertions.first != nil {
-                    presenter.fetchUpdateReviewMovies(.insert)
-
-                } else if modifications.first != nil {
-//                    presenter.fetchUpdateReviewMovies(.modificate)
-
-                }
-                print("更新処理を行いました",deletions, insertions, modifications)
-
-            case let .error(error):
-                print(error)
-            }
-        }
-    }
-    
     func createMovieReview(_ movie: MovieReviewElement) {
         let realmMyMovieInfomation = RealmMyMovieInfomation()
         let realm = try! Realm()

--- a/MovieReviewMVP/Domain/Repositories/MovieRepository.swift
+++ b/MovieReviewMVP/Domain/Repositories/MovieRepository.swift
@@ -13,6 +13,5 @@ protocol MovieReviewRepository {
     func updateMovieReview(_ movie: MovieReviewElement)
     func deleteMovieReview(_ sortState: sortState, _ id: Int)
     func sortMovieReview(_ sortState: sortState, isStoredAsReview: Bool?) -> [MovieReviewElement]
-    mutating func notification(_ presenter: ReviewManagementPresenterInput)
 }
 

--- a/MovieReviewMVP/Domain/UseCases/MovieUseCase.swift
+++ b/MovieReviewMVP/Domain/UseCases/MovieUseCase.swift
@@ -34,10 +34,5 @@ class MovieUseCase {
     func sort(_ sortState: sortState, isStoredAsReview: Bool?) -> [MovieReviewElement] {
         repository.sortMovieReview(sortState, isStoredAsReview: isStoredAsReview)
     }
-    
-    // MARK: 更新通知を受け取る
-    func notification(_ presenter: ReviewManagementPresenterInput) {
-        repository.notification(presenter)
-    }
-    
+        
 }

--- a/MovieReviewMVP/Extension/Notification.Name+Ext.swift
+++ b/MovieReviewMVP/Extension/Notification.Name+Ext.swift
@@ -1,0 +1,12 @@
+//
+//  Notification.Name+Ext.swift
+//  MovieReviewMVP
+//
+//  Created by 坂本龍哉 on 2021/06/28.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let insetReview = Notification.Name("insetReview")
+}

--- a/MovieReviewMVP/ReviewManagement/ReviewManagementCollectionViewController.swift
+++ b/MovieReviewMVP/ReviewManagement/ReviewManagementCollectionViewController.swift
@@ -28,7 +28,6 @@ class ReviewManagementCollectionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setup()
-        movieUseCase.notification(presenter)
         presenter.fetchUpdateReviewMovies(.initial)
         isEditing = false
     }
@@ -57,10 +56,10 @@ private extension ReviewManagementCollectionViewController {
         setupCollectionView()
         setupTrashButton()
         setupStockButton()
+        setupNotification()
     }
     
     func setupTrashButton() {
-        
         trashButton = UIButton()
         trashButton.setImage(UIImage(systemName: .trashImageSystemName), for: .normal)
         
@@ -148,7 +147,6 @@ private extension ReviewManagementCollectionViewController {
     
         
     func setupCollectionView() {
-        
         colunmFlowLayout = ColumnFlowLayout()
         collectionView = UICollectionView(frame: view.bounds, collectionViewLayout: colunmFlowLayout)
         collectionView.autoresizingMask = [ .flexibleWidth, .flexibleHeight]
@@ -170,6 +168,13 @@ private extension ReviewManagementCollectionViewController {
     }
     
     
+    func setupNotification() {
+        NotificationCenter.default.addObserver(self,
+                                       selector: #selector(updateReviewManagementCollectionView),
+                                       name: .insetReview,
+                                       object: nil)
+    }
+
     
 }
 
@@ -187,7 +192,6 @@ extension ReviewManagementCollectionViewController {
     }
     
     @objc func stockButtonTapped() {
-        
         let stockReviewMovieVC = UIStoryboard(name: .StockReviewMovieManagementStoryboardName, bundle: nil).instantiateInitialViewController() as! StockReviewMovieManagementViewController
         let model = StockReviewMovieManagementModel()
         let presenter = StockReviewMovieManagementPresenter(view: stockReviewMovieVC, model: model)
@@ -197,6 +201,9 @@ extension ReviewManagementCollectionViewController {
         self.present(navigationController, animated: true, completion: nil)
     }
     
+    @objc func updateReviewManagementCollectionView() {
+        presenter.fetchUpdateReviewMovies(.insert)
+    }
     
 }
 
@@ -249,7 +256,6 @@ extension ReviewManagementCollectionViewController : UICollectionViewDataSource 
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ReviewManagementCollectionViewCell.identifier, for: indexPath) as! ReviewManagementCollectionViewCell
         let movieReviews = presenter.returnMovieReviewForCell(forRow: indexPath.row)
         if collectionView.indexPathsForSelectedItems?.contains(indexPath) == true {
@@ -262,7 +268,6 @@ extension ReviewManagementCollectionViewController : UICollectionViewDataSource 
     }
     
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
-        
         if kind == UICollectionView.elementKindSectionHeader,
            let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: ReviewMovieManagementCollectionReusableView.identifier, for: indexPath) as? ReviewMovieManagementCollectionReusableView {
             headerView.configure()
@@ -290,7 +295,6 @@ extension ReviewManagementCollectionViewController : ReviewManagementPresenterOu
     
     // MARK: 初期化、削除、挿入、修正を行う
     func updateReview(_ movieUpdateState: MovieUpdateState, index: Int?) {
-        
         switch movieUpdateState {
         case .initial:
             collectionView.reloadData()
@@ -327,7 +331,6 @@ extension ReviewManagementCollectionViewController : ReviewManagementPresenterOu
     
     // MARK: 選択解除を行う
     func changeTheDisplayDependingOnTheEditingState(_ editing: Bool, _ indexPaths: [IndexPath]?) {
-        
         switch editing {
         case true:
             tabBarController?.tabBar.isHidden = true
@@ -360,7 +363,6 @@ extension ReviewManagementCollectionViewController : ReviewManagementPresenterOu
     
     // MARK: tapしたレビューを詳細表示
     func displaySelectMyReview(_ movie: MovieReviewElement, afterStoreState: afterStoreState, movieUpdateState: MovieUpdateState) {
-        
         let reviewMovieVC = UIStoryboard(name: .reviewMovieStoryboardName, bundle: nil).instantiateInitialViewController() as! ReviewMovieViewController
         
         let model = ReviewMovieModel(movie: movie, movieReviewElement: movie)

--- a/MovieReviewMVP/ReviewMovie/ReviewMoviePresenter.swift
+++ b/MovieReviewMVP/ReviewMovie/ReviewMoviePresenter.swift
@@ -31,6 +31,8 @@ final class ReviewMoviePresenter : ReviewMoviePresenterInput {
     private weak var view: ReviewMoviePresenterOutput!
     private var model: ReviewMovieModelInput
     
+
+    
     init(movieReviewState: MovieReviewStoreState,
          movieReviewElement: MovieReviewElement,
          movieUpdateState: MovieUpdateState,
@@ -60,6 +62,24 @@ final class ReviewMoviePresenter : ReviewMoviePresenterInput {
     func returnMovieReviewElement() -> MovieReviewElement {
         movieReviewElement
     }
+
+    func didTapStoreLocationAlert(isStoredAsReview: Bool) {
+        movieReviewElement.isStoredAsReview = isStoredAsReview
+        model.reviewMovie(movieReviewState: movieReviewState, movieReviewElement)
+        NotificationCenter.default.post(name: .insetReview, object: nil)
+        view.closeReviewMovieView(movieUpdateState: movieUpdateState)
+    }
+    
+    func didTapSelectStoreDateAlert(storeDateState: storeDateState) {
+        switch storeDateState {
+        case .stockDate:
+            break
+        case .today:
+            movieReviewElement.create_at = Date()
+        }
+        model.reviewMovie(movieReviewState: movieReviewState, movieReviewElement)
+        view.closeReviewMovieView(movieUpdateState: movieUpdateState)
+    }
     
     // MARK: 保存・更新ボタンが押された時の処理
     func didTapUpdateButton(editing: Bool?, date: Date, reviewScore: Double, review: String?) {
@@ -72,6 +92,7 @@ final class ReviewMoviePresenter : ReviewMoviePresenterInput {
                 movieReviewElement.create_at = date
                 movieReviewElement.reviewStars = reviewScore
                 movieReviewElement.review = checkReview(review: review)
+                
             }
             
         case .afterStore(.reviewed):
@@ -97,22 +118,6 @@ final class ReviewMoviePresenter : ReviewMoviePresenterInput {
         view.displayAfterStoreButtonTapped(primaryKeyIsStored, movieReviewState, editing: editing)
     }
 
-    func didTapStoreLocationAlert(isStoredAsReview: Bool) {
-        movieReviewElement.isStoredAsReview = isStoredAsReview
-        model.reviewMovie(movieReviewState: movieReviewState, movieReviewElement)
-        view.closeReviewMovieView(movieUpdateState: movieUpdateState)
-    }
-    
-    func didTapSelectStoreDateAlert(storeDateState: storeDateState) {
-        switch storeDateState {
-        case .stockDate:
-            break
-        case .today:
-            movieReviewElement.create_at = Date()
-        }
-        model.reviewMovie(movieReviewState: movieReviewState, movieReviewElement)
-        view.closeReviewMovieView(movieUpdateState: movieUpdateState)
-    }
     
 }
 

--- a/MovieReviewMVP/ReviewMovie/ReviewMovieViewController.swift
+++ b/MovieReviewMVP/ReviewMovie/ReviewMovieViewController.swift
@@ -98,10 +98,12 @@ private extension ReviewMovieViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: nil, object: nil)
         reviewMovieOwner.initReviewTextView()
     }
+
     
 }
 // MARK: - @objc
 private extension ReviewMovieViewController {
+    
     @objc func saveButtonTapped(_ sender: UIBarButtonItem) { // textViewに入力がない場合とある場合の保存処理
         let reviewScore = reviewMovieOwner.returnReviewStarScore()
         presenter.didTapUpdateButton(editing: nil,


### PR DESCRIPTION
## 変更点

1. Realmのnotificationを削除
2. NotificationCenterを使って更新処理を追加

## どうやって使うか

1. 削除したので無視
2. searchMovieViewから追加してもReviewManagementViewが更新されるようになりました。

## なぜ変更/追加したか

1. Realmを止める可能性が出てきたため
2. 同上

## スクショ（UI変更がある場合）
