### PR TITLE
広告表示時にisHiddenをfalseにする処理を追加

### DIFF
--- a/MovieReviewMVP/ReviewManagement/ReviewManagementCollectionViewController.swift
+++ b/MovieReviewMVP/ReviewManagement/ReviewManagementCollectionViewController.swift
@@ -488,6 +488,7 @@ extension ReviewManagementCollectionViewController : FUIAuthDelegate {
 
 extension ReviewManagementCollectionViewController : GADBannerViewDelegate {
     func bannerViewDidReceiveAd(_ bannerView: GADBannerView) {
+        bannerView.isHidden = false
         let bannerHeight = CGFloat(50)
         collectionViewBottomAnchor.constant = -bannerHeight
         [trashButtonBottomAnchor,
@@ -502,7 +503,7 @@ extension ReviewManagementCollectionViewController : GADBannerViewDelegate {
 
     func bannerView(_ bannerView: GADBannerView, didFailToReceiveAdWithError error: Error) {
         bannerView.isHidden = true
-      print("bannerView:didFailToReceiveAdWithError: \(error.localizedDescription)")
+        print("bannerView:didFailToReceiveAdWithError: \(error.localizedDescription)")
     }
 
     func bannerViewDidRecordImpression(_ bannerView: GADBannerView) {


### PR DESCRIPTION
## 変更点
広告表示時にbannerを表示状態にする処理を追加
## どうやって使うか
広告表示の際は、isHiddenがfalseになる
## なぜ変更/追加したか
明確にするため。
## スクショ（UI変更がある場合）
