### PR TITLE
SettingManagement画面に戻った時、選択されたセルのハイライトを消す処理を追加しました。

### DIFF
--- a/MovieReviewMVP/SettingManagement/SettingManagementViewController.swift
+++ b/MovieReviewMVP/SettingManagement/SettingManagementViewController.swift
@@ -26,6 +26,13 @@ final class SettingManagementViewController: UIViewController {
         setupBanner()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        if let indexPathForSelectedRow = SettingManagementTableView.indexPathForSelectedRow {
+            SettingManagementTableView.deselectRow(at: indexPathForSelectedRow, animated: true)
+        }
+    }
+    
 }
 
 extension SettingManagementViewController {


### PR DESCRIPTION
#62 
## 変更点
SettingManagement画面に戻った時、選択されたセルのハイライトを消す処理を追加しました。
## どうやって使うか

## なぜ変更/追加したか
画面を戻った時に、セルがハイライトされっぱなしで見にくかったからです。
## スクショ（UI変更がある場合）
